### PR TITLE
align websocket port in server and client

### DIFF
--- a/node-websocket-ex/client/index.html
+++ b/node-websocket-ex/client/index.html
@@ -13,7 +13,7 @@
         -->
         <script>
             const target = document.getElementById("hello");
-            const socket = new WebSocket("ws://localhost:3456");
+            const socket = new WebSocket("ws://localhost:3000");
             socket.onmessage = function(event){
                 target.innerHTML = event.data;
             };


### PR DESCRIPTION
This PR fixes the issue which was discovered and documented by Martin Loh.

> When me and my project partner try to use the node-websocket-ex example, following the instructions of the README file exactly, we both get the same error: Firefox can’t establish a connection to the server at ws://localhost:3456. However, on changing the URL of the WebSocket constructor in index.html from ws://localhost:3456 to ws://localhost:3000, the example works properly. Just sharing this in case anyone else has the same issue, and hopefully Claudia sees this and fixes it.

[source](https://stackoverflow.com/c/tud-cs/articles/3423)